### PR TITLE
ストレージドライバのリンク先を正しいパスに変更する。

### DIFF
--- a/docs/storage/index.html
+++ b/docs/storage/index.html
@@ -112,7 +112,7 @@
 そのデータをコンテナーの外部から取得したいと思っても、外部プロセスがこれを行うことは極めて困難になります。</li>
   <li>コンテナーの書き込み可能レイヤーは、コンテナーが稼動しているホストマシンに強く結び付けられています。
 したがってその中のデータをどこかに移動させることは容易ではありません。</li>
-  <li>コンテナーの書き込み可能レイヤーにデータを書き込むためには、ファイルシステムを管理する <a href="/storage/storagedriver/">ストレージドライバー</a> が必要になります。
+  <li>コンテナーの書き込み可能レイヤーにデータを書き込むためには、ファイルシステムを管理する <a href="/docs.docker.jp.onthefly/storage/storagedriver/">ストレージドライバー</a> が必要になります。
 このストレージドライバーは、Linux カーネルを利用してユニオンファイルシステム（union filesystem）を提供します。
 この特別な抽象ファイルシステムは <strong>データボリューム</strong> に比べると性能が劣ります。
 データボリュームであれば、ホストのファイルシステムに直接データを書き込むことができます。</li>
@@ -311,7 +311,7 @@ Docker ホスト上にて Maven プロジェクトをビルドするたびに、
   <li><a href="/docs.docker.jp.onthefly/storage/volumes/">ボリューム</a> について学ぶ。</li>
   <li><a href="/docs.docker.jp.onthefly/storage/bind-mounts/">バインドマウント</a> について学ぶ。</li>
   <li><a href="/docs.docker.jp.onthefly/storage/tmpfs/">tmpfs マウント</a> について学ぶ。</li>
-  <li><a href="/storage/storagedriver/">ストレージドライバー</a> について学ぶ。
+  <li><a href="/docs.docker.jp.onthefly/storage/storagedriver/">ストレージドライバー</a> について学ぶ。
 これはバインドマウントやボリュームに関連するものではありませんが、
 コンテナーの書き込み可能レイヤーにデータを保存できるものです。</li>
 </ul>


### PR DESCRIPTION
before: `/storage/storagedriver/`
after: `/docs.docker.jp.onthefly/storage/storagedriver/`